### PR TITLE
Various improvements and fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,13 @@
 
 CC = gcc
 CFLAGS = -g -O3 -Wall -MMD
-CXXFLAGS = -O3 -Wall -MMD -DOPENMP -DLEGENDRE
+CXXFLAGS = -O3 -Wall -MMD -DOPENMP -DLEGENDRE -DPRINTPERCENTS
 #-DOPENMP  # use this to run multi-threaded with OPENMP
 #-DPERIODIC # use this to enable periodic behavior
 #-DLEGENDRE # use this to compute 2PCF covariances in Legendre bins
 #-DJACKKNIFE # use this to compute (r,mu)-space 2PCF covariances and jackknife covariances
 #-DTHREE_PCF # use this to compute 3PCF autocovariances
+#-DPRINTPERCENTS # use this to print percentage of progress in each loop. This can be a lot of output
 
 # Known OS-specific choices
 ifeq ($(shell uname -s),Darwin)

--- a/grid_covariance.cpp
+++ b/grid_covariance.cpp
@@ -145,59 +145,81 @@ int main(int argc, char *argv[]) {
         if (par.qbalance) balance_weights(all_particles[index], all_np[index]);
     }
 
-    // Now compute bounding box using all particles
-    Float3 shift; // default value is zero
-    if (!par.make_random) {
-        par.perbox = compute_bounding_box(all_particles, all_np, no_fields, par.rect_boxsize, par.cellsize, par.rmax, shift, par.nside);
-#ifdef PERIODIC
-        par.rect_boxsize = {par.boxsize, par.boxsize, par.boxsize}; // restore the given boxsize if periodic
-        par.cellsize = par.boxsize / (Float)par.nside; // set cell size manually
-        // keep the shift from compute_bounding_box, allowing for coordinate ranges other than [0, par.boxsize) but still of length par.boxsize - this is quite generic and precise at the same time.
-#endif
-    }
-    else {
-        // If randoms particles were made we keep the boxsize
-        par.cellsize = par.boxsize / (Float)par.nside;
-        // set as periodic if we make the random particles
-        par.perbox = true;
-    }
-
     // Now put particles to grid(s)
     Grid all_grid[no_fields]; // create empty grids
     Float max_density = 16., min_density = 2.;
+    int nside_attempts = 3; // number of attempts to meet the constraints by changing nside
+    bool nside_global_failure = true; // assume failure until success
 
-    for (int index = 0; index < no_fields; index++) {
-        // Now ready to compute!
-        // Sort particles into grid(s)
-        Float nofznorm = par.nofznorm;
-        if (index == 1) nofznorm = par.nofznorm2;
-        Grid tmp_grid(all_particles[index], all_np[index], par.rect_boxsize, par.cellsize, par.nside, shift, nofznorm);
-
-        Float grid_density = (Float)tmp_grid.np/tmp_grid.nf;
-        printf("\n RANDOM CATALOG %d DIAGNOSTICS:\n", index+1);
-        printf("Average number of particles per grid cell = %6.2f\n", grid_density);
-        if (grid_density > max_density) {
-            fprintf(stderr,"# ERROR: Average particle density exceeds maximum advised particle density (%.0f particles per cell) - exiting.\n", max_density);
-            exit(1);
+    for (int no_attempt = 0; no_attempt <= nside_attempts; no_attempt++) {
+        // Compute bounding box using all particles. Do it inside the attempt loop because nside could change.
+        Float3 shift; // default value is zero
+        if (!par.make_random) {
+            par.perbox = compute_bounding_box(all_particles, all_np, no_fields, par.rect_boxsize, par.cellsize, par.rmax, shift, par.nside);
+#ifdef PERIODIC
+            par.rect_boxsize = {par.boxsize, par.boxsize, par.boxsize}; // restore the given boxsize if periodic
+            par.cellsize = par.boxsize / (Float)par.nside; // set cell size manually
+            // keep the shift from compute_bounding_box, allowing for coordinate ranges other than [0, par.boxsize) but still of length par.boxsize - this is quite generic and precise at the same time.
+#endif
         }
-        if (grid_density < min_density) {
-            printf("# ERROR: grid appears inefficiently fine (average density less than %.0f particles per cell); exiting.\n", min_density);
-            exit(1);
+        else {
+            // If randoms particles were made we keep the boxsize
+            par.cellsize = par.boxsize / (Float)par.nside;
+            // set as periodic if we make the random particles
+            par.perbox = true;
         }
-        printf("Average number of particles per max_radius ball = %6.2f\n",
-                tmp_grid.np*4.0*M_PI/3.0*pow(par.rmax,3.0)/(par.rect_boxsize.x*par.rect_boxsize.y*par.rect_boxsize.z));
 
-        printf("# Done gridding the particles\n");
-        printf("# %d particles in use, %d with positive weight\n", tmp_grid.np, tmp_grid.np_pos);
-        printf("# Weights: Positive particles sum to %f\n", tmp_grid.sumw_pos);
-        printf("#          Negative particles sum to %f\n", tmp_grid.sumw_neg);
+        // Create grid(s) and see if the particle density is acceptable
+        bool nside_local_success = true; // assume this attempt succeeded be default, can be unset
+        for (int index = 0; index < no_fields; index++) {
+            // Now ready to compute!
+            // Sort particles into grid(s)
+            Float nofznorm = par.nofznorm;
+            if (index == 1) nofznorm = par.nofznorm2;
+            Grid tmp_grid(all_particles[index], all_np[index], par.rect_boxsize, par.cellsize, par.nside, shift, nofznorm);
 
-        // Now save grid to global memory:
-        all_grid[index].copy(&tmp_grid);
+            Float grid_density = (Float)tmp_grid.np/tmp_grid.nf;
+            printf("\n RANDOM CATALOG %d DIAGNOSTICS:\n", index+1);
+            printf("Average number of particles per grid cell = %6.2f\n", grid_density);
+            if (grid_density > max_density) {
+                nside_local_success = false; // unset this attempt's success flag
+                Float aimed_density = cbrt(max_density * max_density * min_density); // aim for density between the limits but closer to max
+                Float nside_approx = cbrt(grid_density/aimed_density) * par.nside; // approximate value of nside to reach this density
+                par.nside = 2 * (int)round((nside_approx + 1)/2) - 1; // round to closest odd integer
+                fprintf(stderr,"# WARNING: Average particle density exceeds maximum advised particle density (%.0f particles per cell). Setting nside=%d.\n", max_density, par.nside);
+                break; // terminate the inner, tracer loop
+            }
+            if (grid_density < min_density) {
+                nside_local_success = false; // unset this attempt's success flag
+                Float aimed_density = cbrt(max_density * min_density * min_density); // aim for density between the limits but closer to min
+                Float nside_approx = cbrt(grid_density/aimed_density) * par.nside; // approximate value of nside to reach this density
+                par.nside = 2 * (int)round((nside_approx + 1)/2) - 1; // round to closest odd integer
+                fprintf(stderr, "# WARNING: grid appears inefficiently fine (average density less than %.0f particles per cell). Setting nside=%d.\n", min_density, par.nside);
+                break; // terminate the inner, tracer loop
+            }
+            printf("Average number of particles per max_radius ball = %6.2f\n",
+                    tmp_grid.np*4.0*M_PI/3.0*pow(par.rmax,3.0)/(par.rect_boxsize.x*par.rect_boxsize.y*par.rect_boxsize.z));
 
-        free(all_particles[index]); // Particles are now only stored in grid
+            printf("# Done gridding the particles\n");
+            printf("# %d particles in use, %d with positive weight\n", tmp_grid.np, tmp_grid.np_pos);
+            printf("# Weights: Positive particles sum to %f\n", tmp_grid.sumw_pos);
+            printf("#          Negative particles sum to %f\n", tmp_grid.sumw_neg);
 
-        fflush(NULL);
+            // Now save grid to global memory:
+            all_grid[index].copy(&tmp_grid);
+
+            free(all_particles[index]); // Particles are now only stored in grid
+
+            fflush(NULL);
+        }
+        if (nside_local_success) {
+            nside_global_failure = false; // unset global failure
+            break; // terminate attempt loop
+        }
+    }
+    if (nside_global_failure) { // report and terminate
+        fprintf(stderr, "# ERROR: could not meet mean grid density constraints after %d additional attempts.\n", nside_attempts);
+        exit(1);
     }
 
     // Print box size and max radius in grid units here, because they are adjusted while reading particles (non-periodic case)

--- a/grid_covariance.cpp
+++ b/grid_covariance.cpp
@@ -222,6 +222,8 @@ int main(int argc, char *argv[]) {
         exit(1);
     }
 
+    // Print the resulting grid size to be sure the stderr messages are not missed
+    printf("Final grid = %d\n", par.nside);
     // Print box size and max radius in grid units here, because they are adjusted while reading particles (non-periodic case)
     printf("Box Size = {%6.5e,%6.5e,%6.5e}\n", par.rect_boxsize.x, par.rect_boxsize.y, par.rect_boxsize.z);
     Float gridsize = par.rmax / par.cellsize;

--- a/modules/compute_integral.h
+++ b/modules/compute_integral.h
@@ -222,12 +222,17 @@
             unsigned long int steps = dist(urandom);
 
             gsl_rng_env_setup(); // initialize gsl rng
+            int completed_loops = 0; // counter of completed loops, since may not finish in index order
+            uint64 used_pairs_per_sample = 0, used_triples_per_sample = 0, used_quads_per_sample = 0; // pair, triple and quad counts for the normalization of the current output sample
 #if (defined LEGENDRE || defined POWER)
             Integrals sumint(par, cf12, cf13, cf24, I1, I2, I3, I4,survey_corr_12,survey_corr_23,survey_corr_34); // total integral
+            Integrals outint(par, cf12, cf13, cf24, I1, I2, I3, I4, survey_corr_12, survey_corr_23, survey_corr_34); // current output integral
 #elif defined JACKKNIFE
             Integrals sumint(par, cf12, cf13, cf24, JK12, JK23, JK34, I1, I2, I3, I4,product_weights12_12,product_weights12_23,product_weights12_34); // total integral
+            Integrals outint(par, cf12, cf13, cf24, JK12, JK23, JK34, I1, I2, I3, I4, product_weights12_12,product_weights12_23, product_weights12_34); // current output integral
 #else
             Integrals sumint(par, cf12, cf13, cf24, JK12, JK23, JK34, I1, I2, I3, I4); // total integral
+            Integrals outint(par, cf12, cf13, cf24, JK12, JK23, JK34, I1, I2, I3, I4); // current output integral
 #endif
             uint64 tot_pairs=0, tot_triples=0, tot_quads=0; // global number of particle pairs/triples/quads used (including those rejected for being in the wrong bins)
             uint64 cell_attempt2=0,cell_attempt3=0,cell_attempt4=0; // number of j,k,l cells attempted
@@ -245,11 +250,11 @@
 #ifdef OPENMP
 
 #if (defined LEGENDRE || defined POWER)
-    #pragma omp parallel firstprivate(steps,par,printtime,grid1,grid2,grid3,grid4,cf12,cf13,cf24) shared(sumint,TotalTime,gsl_rng_default,rd13,rd24) reduction(+:convergence_counter,cell_attempt2,cell_attempt3,cell_attempt4,used_cell2,used_cell3,used_cell4,tot_pairs,tot_triples,tot_quads)
+    #pragma omp parallel firstprivate(steps,par,printtime,grid1,grid2,grid3,grid4,cf12,cf13,cf24) shared(sumint,outint,completed_loops,used_pairs_per_sample,used_triples_per_sample,used_quads_per_sample,TotalTime,gsl_rng_default,rd13,rd24) reduction(+:convergence_counter,cell_attempt2,cell_attempt3,cell_attempt4,used_cell2,used_cell3,used_cell4,tot_pairs,tot_triples,tot_quads)
 #elif defined JACKKNIFE
-    #pragma omp parallel firstprivate(steps,par,printtime,grid1,grid2,grid3,grid4,cf12,cf13,cf24) shared(sumint,TotalTime,ThreadTimes,gsl_rng_default,rd13,rd24,JK12,JK23,JK34,product_weights12_12,product_weights12_23,product_weights12_34) reduction(+:convergence_counter,cell_attempt2,cell_attempt3,cell_attempt4,used_cell2,used_cell3,used_cell4,tot_pairs,tot_triples,tot_quads)
+    #pragma omp parallel firstprivate(steps,par,printtime,grid1,grid2,grid3,grid4,cf12,cf13,cf24) shared(sumint,outint,completed_loops,used_triples_per_sample,used_quads_per_sample,TotalTime,ThreadTimes,gsl_rng_default,rd13,rd24,JK12,JK23,JK34,product_weights12_12,product_weights12_23,product_weights12_34) reduction(+:convergence_counter,cell_attempt2,cell_attempt3,cell_attempt4,used_cell2,used_cell3,used_cell4,tot_pairs,tot_triples,tot_quads)
 #else
-    #pragma omp parallel firstprivate(steps,par,printtime,grid1,grid2,grid3,grid4,cf12,cf13,cf24) shared(sumint,TotalTime,gsl_rng_default,rd13,rd24,JK12,JK23,JK34) reduction(+:convergence_counter,cell_attempt2,cell_attempt3,cell_attempt4,used_cell2,used_cell3,used_cell4,tot_pairs,tot_triples,tot_quads)
+    #pragma omp parallel firstprivate(steps,par,printtime,grid1,grid2,grid3,grid4,cf12,cf13,cf24) shared(sumint,outint,completed_loops,used_triples_per_sample,used_quads_per_sample,TotalTime,gsl_rng_default,rd13,rd24,JK12,JK23,JK34) reduction(+:convergence_counter,cell_attempt2,cell_attempt3,cell_attempt4,used_cell2,used_cell3,used_cell4,tot_pairs,tot_triples,tot_quads)
 #endif
             { // start parallel loop
             // Decide which thread we are in
@@ -444,46 +449,55 @@
     #pragma omp critical // only one processor can access at once
     #endif
             {
-                if ((n_loops+1)%par->nthread==0){ // Print every nthread loops
+                int subsample_index = completed_loops / par->loops_per_sample; // index of output subsample for this loop
+                completed_loops++; // increment completed loops counter, since they may be done not according to n_loops order
+                if (completed_loops % par->nthread == 0) { // Print every nthread completed loops
                     TotalTime.Stop(); // interrupt timing to access .Elapsed()
                     int current_runtime = TotalTime.Elapsed();
-                    int remaining_time = current_runtime/((n_loops+1)/par->nthread)*(par->max_loops/par->nthread-(n_loops+1)/par->nthread);  // estimated remaining time
-                    fprintf(stderr,"\nFinished integral loop %d of %d after %d s. Estimated time left:  %2.2d:%2.2d:%2.2d hms, i.e. %d s.\n",n_loops+1,par->max_loops, current_runtime,remaining_time/3600,remaining_time/60%60, remaining_time%60,remaining_time);
+                    int remaining_time = current_runtime*(par->max_loops - completed_loops)/completed_loops;  // estimated remaining time
+                    fprintf(stderr, "\nFinished %d integral loops of %d after %d s. Estimated time left:  %2.2d:%2.2d:%2.2d hms, i.e. %d s.\n", completed_loops, par->max_loops, current_runtime, remaining_time/3600, remaining_time/60%60, remaining_time%60, remaining_time);
 
                     TotalTime.Start(); // Restart the timer
                     Float frob_C2, frob_C3, frob_C4;
 #ifndef JACKKNIFE
-                    sumint.frobenius_difference_sum(&locint,n_loops, frob_C2, frob_C3, frob_C4);
+                    sumint.frobenius_difference_sum(&locint, n_loops, frob_C2, frob_C3, frob_C4);
                     if(frob_C4 < par->convergence_threshold_percent) convergence_counter++;
-                    if (n_loops!=0){
-                        fprintf(stderr,"Frobenius percent difference after loop %d is %.3f (C2), %.3f (C3), %.3f (C4)\n",n_loops,frob_C2, frob_C3, frob_C4);
-                    }
+                    fprintf(stderr, "Frobenius percent difference after %d loops is %.3f (C2), %.3f (C3), %.3f (C4)\n", completed_loops, frob_C2, frob_C3, frob_C4);
 #else
                     Float frob_C2j, frob_C3j, frob_C4j;
-                    sumint.frobenius_difference_sum(&locint,n_loops, frob_C2, frob_C3, frob_C4, frob_C2j, frob_C3j, frob_C4j);
+                    sumint.frobenius_difference_sum(&locint, n_loops, frob_C2, frob_C3, frob_C4, frob_C2j, frob_C3j, frob_C4j);
                     if((frob_C4 < par->convergence_threshold_percent) && (frob_C4j < par->convergence_threshold_percent)) convergence_counter++;
-                    if (n_loops!=0){
-                        fprintf(stderr,"Frobenius percent difference after loop %d is %.3f (C2), %.3f (C3), %.3f (C4)\n",n_loops,frob_C2, frob_C3, frob_C4);
-                        fprintf(stderr,"Frobenius jackknife percent difference after loop %d is %.3f (C2j), %.3f (C3j), %.3f (C4j)\n",n_loops,frob_C2j, frob_C3j, frob_C4j);
-                    }
+                    fprintf(stderr, "Frobenius percent difference after %d loops is %.3f (C2), %.3f (C3), %.3f (C4)\n", completed_loops, frob_C2, frob_C3, frob_C4);
+                    fprintf(stderr, "Frobenius jackknife percent difference after %d loops is %.3f (C2j), %.3f (C3j), %.3f (C4j)\n", completed_loops, frob_C2j, frob_C3j, frob_C4j);
 #endif
                 }
 
                 // Sum up integrals
-                sumint.sum_ints(&locint);
+                outint.sum_ints(&locint); // subsample total
 
-                // Save output after each loop
-                char output_string[50];
-                snprintf(output_string, 50, "%d", n_loops);
+                // Sum up pairs, triples, quads for the group
+                used_pairs_per_sample += loc_used_pairs;
+                used_triples_per_sample += loc_used_triples;
+                used_quads_per_sample += loc_used_quads;
+
+                // Save output if the group is done
+                if (completed_loops % par->loops_per_sample == 0) {
+                    sumint.sum_ints(&outint); // add to grand total
+                    char output_string[50];
+                    snprintf(output_string, 50, "%d", subsample_index);
 #ifndef POWER
-                locint.normalize(grid1->norm,grid2->norm,grid3->norm,grid4->norm,(Float)loc_used_pairs, (Float)loc_used_triples, (Float)loc_used_quads);
+                    outint.normalize(grid1->norm, grid2->norm, grid3->norm, grid4->norm, (Float)used_pairs_per_sample, (Float)used_triples_per_sample, (Float)used_quads_per_sample);
 #else
-                locint.normalize(grid1->norm,grid2->norm,grid3->norm,grid4->norm,(Float)loc_used_pairs, (Float)loc_used_triples, (Float)loc_used_quads, par->power_norm);
+                    outint.normalize(grid1->norm, grid2->norm, grid3->norm, grid4->norm, (Float)used_pairs_per_sample, (Float)used_triples_per_sample, (Float)used_quads_per_sample, par->power_norm);
 #endif
-                locint.save_integrals(output_string,0);
+                    outint.save_integrals(output_string, 0);
 #ifdef JACKKNIFE
-                locint.save_jackknife_integrals(output_string);
+                    outint.save_jackknife_integrals(output_string);
 #endif
+                    // Reset the current output sample variables
+                    outint.reset();
+                    used_pairs_per_sample = used_triples_per_sample = used_quads_per_sample = 0;
+                }
                 locint.sum_total_counts(cnt2, cnt3, cnt4);
                 locint.reset();
 

--- a/modules/compute_integral.h
+++ b/modules/compute_integral.h
@@ -460,11 +460,11 @@
                     TotalTime.Start(); // Restart the timer
                     Float frob_C2, frob_C3, frob_C4;
 #ifndef JACKKNIFE
-                    sumint.frobenius_difference_sum(&locint, n_loops, frob_C2, frob_C3, frob_C4);
+                    sumint.frobenius_difference_sum(&locint, subsample_index * par->loops_per_sample, frob_C2, frob_C3, frob_C4); // since sumint is only incremented every loops_per_sample iterations, subsample_index * loops_per_sample is exactly how many loops are stored in the sumint at the moment. Thus if loops_per_sample>1 the Frobenius percent difference may be an overestimate.
                     fprintf(stderr, "Frobenius percent difference after %d loops is %.3f (C2), %.3f (C3), %.3f (C4)\n", completed_loops, frob_C2, frob_C3, frob_C4);
 #else
                     Float frob_C2j, frob_C3j, frob_C4j;
-                    sumint.frobenius_difference_sum(&locint, n_loops, frob_C2, frob_C3, frob_C4, frob_C2j, frob_C3j, frob_C4j);
+                    sumint.frobenius_difference_sum(&locint, subsample_index * par->loops_per_sample, frob_C2, frob_C3, frob_C4, frob_C2j, frob_C3j, frob_C4j); // since sumint is only incremented every loops_per_sample iterations, subsample_index * loops_per_sample is exactly how many loops are stored in the sumint at the moment. Thus if loops_per_sample>1 the Frobenius percent difference may be an overestimate.
                     fprintf(stderr, "Frobenius percent difference after %d loops is %.3f (C2), %.3f (C3), %.3f (C4)\n", completed_loops, frob_C2, frob_C3, frob_C4);
                     fprintf(stderr, "Frobenius jackknife percent difference after %d loops is %.3f (C2j), %.3f (C3j), %.3f (C4j)\n", completed_loops, frob_C2j, frob_C3j, frob_C4j);
 #endif

--- a/modules/compute_integral.h
+++ b/modules/compute_integral.h
@@ -280,7 +280,9 @@
             int *bin_ij; // i-j separation bin
             int mnp = grid1->maxnp; // max number of particles in a grid1 cell
             Float *xi_ik, *w_ijk, *w_ij; // arrays to store xi and weight values
+#ifdef PRINTPERCENTS
             Float percent_counter;
+#endif
             int x, prim_id_1D;
             integer3 delta2, delta3, delta4, prim_id, sec_id, thi_id;
             Float3 cell_sep2,cell_sep3;
@@ -324,18 +326,22 @@
     #pragma omp for schedule(dynamic)
     #endif
             for (int n_loops = 0; n_loops<par->max_loops; n_loops++){
+#ifdef PRINTPERCENTS
                 percent_counter=0.;
+#endif
                 loc_used_pairs=0; loc_used_triples=0; loc_used_quads=0;
                 LoopTimes[n_loops].Start();
 
                 // LOOP OVER ALL FILLED I CELLS
                 for (int n1=0; n1<grid1->nf;n1++){
 
+#ifdef PRINTPERCENTS
                     // Print time left
                     if((float(n1)/float(grid1->nf)*100)>=percent_counter){
                         printf("Integral %d of %d, iteration %d of %d on thread %d: Using cell %d of %d - %.0f percent complete\n", iter_no, tot_iter, 1+n_loops, par->max_loops, thread, n1+1, grid1->nf, percent_counter);
                         percent_counter+=5.;
                     }
+#endif
 
                     // Pick first particle
                     prim_id_1D = grid1-> filled[n1]; // 1d ID for cell i

--- a/modules/compute_integral.h
+++ b/modules/compute_integral.h
@@ -448,6 +448,7 @@
     #pragma omp critical // only one processor can access at once
     #endif
             {
+                printf("Integral %d of %d, iteration %d of %d on thread %d completed\n", iter_no, tot_iter, 1+n_loops, par->max_loops, thread);
                 int subsample_index = completed_loops / par->loops_per_sample; // index of output subsample for this loop
                 completed_loops++; // increment completed loops counter, since they may be done not according to n_loops order
                 if (completed_loops % par->nthread == 0) { // Print every nthread completed loops

--- a/modules/compute_integral.h
+++ b/modules/compute_integral.h
@@ -249,11 +249,11 @@
 #ifdef OPENMP
 
 #if (defined LEGENDRE || defined POWER)
-    #pragma omp parallel firstprivate(seed_step,seed_shift,par,grid1,grid2,grid3,grid4,cf12,cf13,cf24) shared(sumint,outint,completed_loops,used_pairs_per_sample,used_triples_per_sample,used_quads_per_sample,TotalTime,gsl_rng_default,rd13,rd24) reduction(+:cell_attempt2,cell_attempt3,cell_attempt4,used_cell2,used_cell3,used_cell4,tot_pairs,tot_triples,tot_quads)
+    #pragma omp parallel firstprivate(seed_step,seed_shift,par,grid1,grid2,grid3,grid4,cf12,cf13,cf24) shared(sumint,outint,completed_loops,used_pairs_per_sample,used_triples_per_sample,used_quads_per_sample,TotalTime,LoopTimes,gsl_rng_default,rd13,rd24) reduction(+:cell_attempt2,cell_attempt3,cell_attempt4,used_cell2,used_cell3,used_cell4,tot_pairs,tot_triples,tot_quads)
 #elif defined JACKKNIFE
-    #pragma omp parallel firstprivate(seed_step,seed_shift,par,grid1,grid2,grid3,grid4,cf12,cf13,cf24) shared(sumint,outint,completed_loops,used_triples_per_sample,used_quads_per_sample,TotalTime,ThreadTimes,gsl_rng_default,rd13,rd24,JK12,JK23,JK34,product_weights12_12,product_weights12_23,product_weights12_34) reduction(+:cell_attempt2,cell_attempt3,cell_attempt4,used_cell2,used_cell3,used_cell4,tot_pairs,tot_triples,tot_quads)
+    #pragma omp parallel firstprivate(seed_step,seed_shift,par,grid1,grid2,grid3,grid4,cf12,cf13,cf24) shared(sumint,outint,completed_loops,used_triples_per_sample,used_quads_per_sample,TotalTime,LoopTimes,gsl_rng_default,rd13,rd24,JK12,JK23,JK34,product_weights12_12,product_weights12_23,product_weights12_34) reduction(+:cell_attempt2,cell_attempt3,cell_attempt4,used_cell2,used_cell3,used_cell4,tot_pairs,tot_triples,tot_quads)
 #else
-    #pragma omp parallel firstprivate(seed_step,seed_shift,par,grid1,grid2,grid3,grid4,cf12,cf13,cf24) shared(sumint,outint,completed_loops,used_triples_per_sample,used_quads_per_sample,TotalTime,gsl_rng_default,rd13,rd24,JK12,JK23,JK34) reduction(+:cell_attempt2,cell_attempt3,cell_attempt4,used_cell2,used_cell3,used_cell4,tot_pairs,tot_triples,tot_quads)
+    #pragma omp parallel firstprivate(seed_step,seed_shift,par,grid1,grid2,grid3,grid4,cf12,cf13,cf24) shared(sumint,outint,completed_loops,used_triples_per_sample,used_quads_per_sample,TotalTime,LoopTimes,gsl_rng_default,rd13,rd24,JK12,JK23,JK34) reduction(+:cell_attempt2,cell_attempt3,cell_attempt4,used_cell2,used_cell3,used_cell4,tot_pairs,tot_triples,tot_quads)
 #endif
             { // start parallel loop
             // Decide which thread we are in

--- a/modules/compute_integral.h
+++ b/modules/compute_integral.h
@@ -156,8 +156,6 @@
             STimer initial, TotalTime; // Time initialization
             initial.Start();
 
-            int convergence_counter=0, printtime=0;// counter to stop loop early if convergence is reached.
-
 #ifdef JACKKNIFE
     // --------Compute product weights----------------------
             int nbins=nbin*mbin;
@@ -250,11 +248,11 @@
 #ifdef OPENMP
 
 #if (defined LEGENDRE || defined POWER)
-    #pragma omp parallel firstprivate(steps,par,printtime,grid1,grid2,grid3,grid4,cf12,cf13,cf24) shared(sumint,outint,completed_loops,used_pairs_per_sample,used_triples_per_sample,used_quads_per_sample,TotalTime,gsl_rng_default,rd13,rd24) reduction(+:convergence_counter,cell_attempt2,cell_attempt3,cell_attempt4,used_cell2,used_cell3,used_cell4,tot_pairs,tot_triples,tot_quads)
+    #pragma omp parallel firstprivate(steps,par,grid1,grid2,grid3,grid4,cf12,cf13,cf24) shared(sumint,outint,completed_loops,used_pairs_per_sample,used_triples_per_sample,used_quads_per_sample,TotalTime,gsl_rng_default,rd13,rd24) reduction(+:cell_attempt2,cell_attempt3,cell_attempt4,used_cell2,used_cell3,used_cell4,tot_pairs,tot_triples,tot_quads)
 #elif defined JACKKNIFE
-    #pragma omp parallel firstprivate(steps,par,printtime,grid1,grid2,grid3,grid4,cf12,cf13,cf24) shared(sumint,outint,completed_loops,used_triples_per_sample,used_quads_per_sample,TotalTime,ThreadTimes,gsl_rng_default,rd13,rd24,JK12,JK23,JK34,product_weights12_12,product_weights12_23,product_weights12_34) reduction(+:convergence_counter,cell_attempt2,cell_attempt3,cell_attempt4,used_cell2,used_cell3,used_cell4,tot_pairs,tot_triples,tot_quads)
+    #pragma omp parallel firstprivate(steps,par,grid1,grid2,grid3,grid4,cf12,cf13,cf24) shared(sumint,outint,completed_loops,used_triples_per_sample,used_quads_per_sample,TotalTime,ThreadTimes,gsl_rng_default,rd13,rd24,JK12,JK23,JK34,product_weights12_12,product_weights12_23,product_weights12_34) reduction(+:cell_attempt2,cell_attempt3,cell_attempt4,used_cell2,used_cell3,used_cell4,tot_pairs,tot_triples,tot_quads)
 #else
-    #pragma omp parallel firstprivate(steps,par,printtime,grid1,grid2,grid3,grid4,cf12,cf13,cf24) shared(sumint,outint,completed_loops,used_triples_per_sample,used_quads_per_sample,TotalTime,gsl_rng_default,rd13,rd24,JK12,JK23,JK34) reduction(+:convergence_counter,cell_attempt2,cell_attempt3,cell_attempt4,used_cell2,used_cell3,used_cell4,tot_pairs,tot_triples,tot_quads)
+    #pragma omp parallel firstprivate(steps,par,grid1,grid2,grid3,grid4,cf12,cf13,cf24) shared(sumint,outint,completed_loops,used_triples_per_sample,used_quads_per_sample,TotalTime,gsl_rng_default,rd13,rd24,JK12,JK23,JK34) reduction(+:cell_attempt2,cell_attempt3,cell_attempt4,used_cell2,used_cell3,used_cell4,tot_pairs,tot_triples,tot_quads)
 #endif
             { // start parallel loop
             // Decide which thread we are in
@@ -329,12 +327,6 @@
                 loc_used_pairs=0; loc_used_triples=0; loc_used_quads=0;
                 LoopTimes[n_loops].Start();
 
-                // End loops early if convergence has been acheived
-                if (convergence_counter == par->convergence_ntimes){
-                    if (printtime==0) printf("%.2lf percent convergence achieved in C4 %d times, exiting.\n", par->convergence_threshold_percent, par->convergence_ntimes);
-                    printtime++;
-                    continue;
-                    }
                 // LOOP OVER ALL FILLED I CELLS
                 for (int n1=0; n1<grid1->nf;n1++){
 
@@ -461,12 +453,10 @@
                     Float frob_C2, frob_C3, frob_C4;
 #ifndef JACKKNIFE
                     sumint.frobenius_difference_sum(&locint, n_loops, frob_C2, frob_C3, frob_C4);
-                    if(frob_C4 < par->convergence_threshold_percent) convergence_counter++;
                     fprintf(stderr, "Frobenius percent difference after %d loops is %.3f (C2), %.3f (C3), %.3f (C4)\n", completed_loops, frob_C2, frob_C3, frob_C4);
 #else
                     Float frob_C2j, frob_C3j, frob_C4j;
                     sumint.frobenius_difference_sum(&locint, n_loops, frob_C2, frob_C3, frob_C4, frob_C2j, frob_C3j, frob_C4j);
-                    if((frob_C4 < par->convergence_threshold_percent) && (frob_C4j < par->convergence_threshold_percent)) convergence_counter++;
                     fprintf(stderr, "Frobenius percent difference after %d loops is %.3f (C2), %.3f (C3), %.3f (C4)\n", completed_loops, frob_C2, frob_C3, frob_C4);
                     fprintf(stderr, "Frobenius jackknife percent difference after %d loops is %.3f (C2j), %.3f (C3j), %.3f (C4j)\n", completed_loops, frob_C2j, frob_C3j, frob_C4j);
 #endif

--- a/modules/parameters.h
+++ b/modules/parameters.h
@@ -81,6 +81,10 @@ public:
 
     // Maximum number of iterations to compute the C_ab integrals over
     int max_loops = 40;
+    // Number of loops to output into each subsample/file
+    int loops_per_sample = 1;
+    // Number of output subsamples/files
+    int no_subsamples = 120;
 
     // Exit after relative Frobenius difference is less than (convergence_threshold_percent %) for (convergence_ntimes) times
     Float convergence_threshold_percent = 0.01;
@@ -222,7 +226,8 @@ public:
                 Float tmp_box=atof(argv[++i]);
                 rect_boxsize = {tmp_box,tmp_box,tmp_box};
                 }
-        else if (!strcmp(argv[i],"-maxloops")) max_loops = atof(argv[++i]);
+        else if (!strcmp(argv[i],"-maxloops")) max_loops = atoi(argv[++i]);
+        else if (!strcmp(argv[i],"-loopspersample")) loops_per_sample = atoi(argv[++i]);
         else if (!strcmp(argv[i],"-rescale")) rescale = atof(argv[++i]);
 		else if (!strcmp(argv[i],"-mumax")) mumax = atof(argv[++i]);
 		else if (!strcmp(argv[i],"-mumin")) mumin = atof(argv[++i]);
@@ -320,6 +325,8 @@ public:
 	    assert(nside%2!=0); // The probability integrator needs an odd grid size
 
 	    assert(nofznorm>0); // need some galaxies!
+        assert(max_loops % loops_per_sample == 0); // group size need to divide the number of loops
+        no_subsamples = max_loops / loops_per_sample;
 #ifndef THREE_PCF
 	    //assert(mumin>=0); // We take the absolte value of mu
 #endif
@@ -504,6 +511,7 @@ public:
 #endif
 		printf("Number of galaxies = %6.5e\n",nofznorm);
         printf("Maximum number of integration loops = %d\n",max_loops);
+        printf("Number of output subsamples = %d\n", no_subsamples);
         printf("Output directory: '%s'\n",out_file);
 
 	}
@@ -565,6 +573,7 @@ private:
         fprintf(stderr, "   -jackknife2 <filename>: (Optional) File containing the {2,2} jackknife weights (normally computed from Corrfunc)\n");
 #endif
         fprintf(stderr, "   -maxloops <max_loops>: Maximum number of integral loops\n");
+        fprintf(stderr, "   -loopspersample <loops_per_sample>: Number of loops to collapse into each subsample. Default 1.\n");
         fprintf(stderr, "   -N2 <N2>: Number of secondary particles to choose per primary particle\n");
         fprintf(stderr, "   -N3 <N3>: Number of tertiary particles to choose per secondary particle\n");
         fprintf(stderr, "   -N4 <N4>: Number of quaternary particles to choose per tertiary particle\n");

--- a/modules/parameters.h
+++ b/modules/parameters.h
@@ -86,10 +86,6 @@ public:
     // Number of output subsamples/files
     int no_subsamples = 120;
 
-    // Exit after relative Frobenius difference is less than (convergence_threshold_percent %) for (convergence_ntimes) times
-    Float convergence_threshold_percent = 0.01;
-    int convergence_ntimes = 10;
-
     // Number of random cells to draw at each stage
     int N2 = 20; // number of j cells per i cell
     int N3 = 40; // number of k cells per j cell

--- a/modules/rescale_correlation.h
+++ b/modules/rescale_correlation.h
@@ -3,6 +3,8 @@
 #ifndef RESCALE_CORRELATION_H
 #define RESCALE_CORRELATION_H
 
+#include <algorithm>
+
 class correlation_integral{
 public:
     Float *cf_estimate; // estimated correlation function in each bin
@@ -54,16 +56,11 @@ private:
         // Linearizes 2D indices - needs CORRELATION FUNCTION bins here, not covariance binning (i.e. should extend to zero)
 
         // First define which r bin we are in;
-        int which_bin = -1; // default if outside bins
-        for(int i=0;i<nbin;i++){
-            if((r>r_low[i])&&(r<r_high[i])){
-                which_bin=i;
-                break;
-            }
-            if((i==nbin-1)&&(r>r_high[i])){
-                which_bin=nbin; // if above top bin
-            }
-        }
+        Float* r_higher = std::upper_bound(r_high, r_high + nbin, r); // binary search for r_high element higher than r
+        int which_bin = r_higher - r_high; // bin index is pointer difference; will be nbin if value not found, i.e. if we are above top bin
+        if (which_bin < nbin) // safety check unless we are above top bin already
+            if (r < r_low[which_bin]) // r < r_high[which_bin] is guaranteed above so only need to check that r >= r_low[which_bin]
+                which_bin = -1; // if not then no bin fits the bill
         return which_bin*mbin + floor((mu-mumin)/dmu);
     }
 

--- a/python/RR_counts.py
+++ b/python/RR_counts.py
@@ -21,24 +21,9 @@ outdir=str(sys.argv[7])
 normed=int(sys.argv[8])
 
 ## First read in weights and positions:
-dtype = np.double 
-
-print("Counting lines in file")
-total_lines=0
-for n, line in enumerate(open(fname, 'r')):
-    total_lines+=1
-
-X,Y,Z,W=[np.zeros(total_lines) for _ in range(4)]
 
 print("Reading in data");
-for n, line in enumerate(open(fname, 'r')):
-    if n%1000000==0:
-        print("Reading line %d of %d" %(n,total_lines))
-    split_line=np.array(line.split(" "), dtype=float) 
-    X[n]=split_line[0];
-    Y[n]=split_line[1];
-    Z[n]=split_line[2];
-    W[n]=split_line[3];
+X, Y, Z, W = np.loadtxt(fname, usecols=range(4)).T
     
 N = len(X) # number of particles
 weight_sum = np.sum(W)#  normalization by summed weights

--- a/python/RR_counts_multi.py
+++ b/python/RR_counts_multi.py
@@ -22,40 +22,12 @@ outdir=str(sys.argv[8])
 normed=int(sys.argv[9])
 
 ## First read in weights and positions:
-dtype = np.double 
 
-print("Counting lines in file 1")
-total_lines=0
-for n, line in enumerate(open(fname, 'r')):
-    total_lines+=1
+print("Reading in data for file 1")
+X, Y, Z, W = np.loadtxt(fname, usecols=range(4)).T
     
-print("Counting lines in file 2")
-total_lines2=0
-for n, line in enumerate(open(fname2, 'r')):
-    total_lines2+=1
-
-X,Y,Z,W=[np.zeros(total_lines) for _ in range(4)]
-X2,Y2,Z2,W2=[np.zeros(total_lines2) for _ in range(4)]
-
-print("\nReading in data for file 1");
-for n, line in enumerate(open(fname, 'r')):
-    if n%1000000==0:
-        print("Reading line %d of %d" %(n,total_lines))
-    split_line=np.array(line.split(" "), dtype=float) 
-    X[n]=split_line[0];
-    Y[n]=split_line[1];
-    Z[n]=split_line[2];
-    W[n]=split_line[3];
-    
-print("\nReading in data for file 2");
-for n, line in enumerate(open(fname2, 'r')):
-    if n%1000000==0:
-        print("Reading line %d of %d" %(n,total_lines2))
-    split_line=np.array(line.split(" "), dtype=float) 
-    X2[n]=split_line[0];
-    Y2[n]=split_line[1];
-    Z2[n]=split_line[2];
-    W2[n]=split_line[3];
+print("Reading in data for file 2")
+X2, Y2, Z2, W2 = np.loadtxt(fname2, usecols=range(4)).T
     
 N = len(X) # number of particles
 N2 = len(X2)

--- a/python/cat_subsets_of_integrals.py
+++ b/python/cat_subsets_of_integrals.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 import sys,os
-from tqdm import tqdm
+from tqdm import trange
 from shutil import copy2
 
 # PARAMETERS
@@ -65,7 +65,7 @@ for ii in range(len(I1)): # loop over all field combinations
             except (FileNotFoundError, IOError): pass
         if read_all:
             if os.path.isfile(input_root_all+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, n_samples-1)):
-                for i in tqdm(range(n_samples), desc="Reading %s full samples" % index4):
+                for i in trange(n_samples, desc="Loading %s full samples" % index4):
                     c2.append(np.loadtxt(input_root_all+'c2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i)))
                     c3.append(np.loadtxt(input_root_all+'c3_n%d_%s_%s_%s.txt' % (n, mstr, index3, i)))
                     c4.append(np.loadtxt(input_root_all+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, i)))
@@ -84,14 +84,14 @@ for ii in range(len(I1)): # loop over all field combinations
     if collapse_factor > 1:
         c2, c3, c4 = [np.mean(a.reshape(n_samples_out, collapse_factor, *np.shape(a)[1:]), axis=1) for a in (c2, c3, c4)] # average adjacent chunks of collapse_factor samples; repeats must be trivial in this case
         # write the collapsed data
-        for i in tqdm(range(n_samples_out), desc="Writing %s full samples" % index4):
+        for i in trange(n_samples_out, desc="Writing %s full samples" % index4):
             np.savetxt(output_root_all+'c2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i), c2[i])
             np.savetxt(output_root_all+'c3_n%d_%s_%s_%s.txt' % (n, mstr, index3, i), c3[i])
             np.savetxt(output_root_all+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, i), c4[i])
     else: # can copy files, which should be faster
         c2, c3, c4 = [None] * 3 # won't be needed, so can free memory
         for input_root_all, n_samples, sample_offset in zip(input_roots_all, ns_samples, sample_offsets):
-            for i in tqdm(range(n_samples), desc="Copying %s full samples" % index4):
+            for i in trange(n_samples, desc="Copying %s full samples" % index4):
                 copy2(input_root_all+'c2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i), output_root_all+'c2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i + sample_offset))
                 copy2(input_root_all+'c3_n%d_%s_%s_%s.txt' % (n, mstr, index3, i), output_root_all+'c3_n%d_%s_%s_%s.txt' % (n, mstr, index3, i + sample_offset))
                 copy2(input_root_all+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, i), output_root_all+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, i + sample_offset))
@@ -119,7 +119,7 @@ for ii in range(len(I1)): # loop over all field combinations
             except (FileNotFoundError, IOError): pass
         if read_all:
             if os.path.isfile(input_root_jack+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, n_samples-1)):
-                for i in tqdm(range(n_samples), desc="Reading %s jack samples" % index4):
+                for i in trange(n_samples, desc="Loading %s jack samples" % index4):
                     c2j.append(np.loadtxt(input_root_jack+'c2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i)))
                     c3j.append(np.loadtxt(input_root_jack+'c3_n%d_%s_%s_%s.txt' % (n, mstr, index3, i)))
                     c4j.append(np.loadtxt(input_root_jack+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, i)))
@@ -148,7 +148,7 @@ for ii in range(len(I1)): # loop over all field combinations
     if collapse_factor > 1:
         c2j, c3j, c4j, EEaA1, EEaA2, RRaA1, RRaA2 = [np.mean(a.reshape(n_samples_out, collapse_factor, *np.shape(a)[1:]), axis=1) for a in (c2j, c3j, c4j, EEaA1, EEaA2, RRaA1, RRaA2)] # average adjacent chunks of collapse_factor samples
         # write the collapsed data
-        for i in tqdm(range(n_samples_out), desc="Writing %s jack samples" % index4):
+        for i in trange(n_samples_out, desc="Writing %s jack samples" % index4):
             np.savetxt(output_root_jack+'c2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i), c2j[i])
             np.savetxt(output_root_jack+'c3_n%d_%s_%s_%s.txt' % (n, mstr, index3, i), c3j[i])
             np.savetxt(output_root_jack+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, i), c4j[i])
@@ -160,7 +160,7 @@ for ii in range(len(I1)): # loop over all field combinations
     else: # can copy files, which should be faster
         c2j, c3j, c4j, EEaA1, EEaA2, RRaA1, RRaA2 = [None] * 7 # won't be needed, so can free memory
         for input_root_jack, n_samples, sample_offset in zip(input_roots_jack, ns_samples, sample_offsets):
-            for i in tqdm(range(n_samples), desc="Copying %s full samples" % index4):
+            for i in trange(n_samples, desc="Copying %s full samples" % index4):
                 copy2(input_root_jack+'c2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i), output_root_jack+'c2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i + sample_offset))
                 copy2(input_root_jack+'c3_n%d_%s_%s_%s.txt' % (n, mstr, index3, i), output_root_jack+'c3_n%d_%s_%s_%s.txt' % (n, mstr, index3, i + sample_offset))
                 copy2(input_root_jack+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, i), output_root_jack+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, i + sample_offset))

--- a/python/cat_subsets_of_integrals.py
+++ b/python/cat_subsets_of_integrals.py
@@ -6,6 +6,7 @@
 import numpy as np
 import sys,os
 from tqdm import tqdm
+from shutil import copy2
 
 # PARAMETERS
 if len(sys.argv)<6: # if too few
@@ -18,11 +19,13 @@ input_roots = [str(s) for s in sys.argv[3:-1:2]]
 ns_samples = [int(s) for s in sys.argv[4:-1:2]]
 output_root = str(sys.argv[-1])
 collapse_factor = int(input_roots.pop()) if len(input_roots) > len(ns_samples) else 1 # recover the collapse factor if present
-assert len(ns_samples) == len(output_root), "Number of input dirs and subsamples to use from them must be the same"
+assert collapse_factor > 0, "Collapsing factor must be positive"
+assert len(ns_samples) == len(input_roots), "Number of input dirs and subsamples to use from them must be the same"
 
 n_samples_tot = sum(ns_samples)
 assert n_samples_tot % collapse_factor == 0, "Collapse factor must divide the total number of samples"
 n_samples_out = n_samples_tot // collapse_factor
+if collapse_factor == 1: sample_offsets = [0] + list(np.cumsum(ns_samples[:-1]))
 
 input_roots_all = [os.path.join(input_root, 'CovMatricesAll/') for input_root in input_roots]
 input_roots_jack = [os.path.join(input_root, 'CovMatricesJack/') for input_root in input_roots]
@@ -47,72 +50,123 @@ for ii in range(len(I1)): # loop over all field combinations
 
     # full integrals
     c2, c3, c4 = [], [], []
+    repeats = []
     # read
     for input_root_all, n_samples in zip(input_roots_all, ns_samples):
-        for i in tqdm(range(n_samples), desc="Reading %s full samples from %s" % (index4, input_root_all)):
+        read_all = True
+        if collapse_factor == 1 and not os.path.isfile(input_root_all+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, n_samples)):
+            # if don't want to collapse and there are no more samples than we are using, can read averages from full file
             try:
-                c2.append(np.loadtxt(input_root_all+'c2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i)))
-            except (FileNotFoundError, IOError): break # end loop if c2 full not found
-            c3.append(np.loadtxt(input_root_all+'c3_n%d_%s_%s_%s.txt' % (n, mstr, index3, i)))
-            c4.append(np.loadtxt(input_root_all+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, i)))
-    if len(c2) == 0: break # end loop if no full integral has been found
-    if len(c2) < n_samples_tot:
-        print("ERROR: some %s full samples missing: expected %d, found %d" % (index4, n_samples_tot, len(c2)))
+                c2.append(np.loadtxt(input_root_all+'c2_n%d_%s_%s_full.txt' % (n, mstr, index2)))
+                c3.append(np.loadtxt(input_root_all+'c3_n%d_%s_%s_full.txt' % (n, mstr, index3)))
+                c4.append(np.loadtxt(input_root_all+'c4_n%d_%s_%s_full.txt' % (n, mstr, index4)))
+                repeats.append(n_samples)
+                read_all = False
+            except (FileNotFoundError, IOError): pass
+        if read_all:
+            if os.path.isfile(input_root_all+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, n_samples-1)):
+                for i in tqdm(range(n_samples), desc="Reading %s full samples" % index4):
+                    c2.append(np.loadtxt(input_root_all+'c2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i)))
+                    c3.append(np.loadtxt(input_root_all+'c3_n%d_%s_%s_%s.txt' % (n, mstr, index3, i)))
+                    c4.append(np.loadtxt(input_root_all+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, i)))
+                    repeats.append(1)
+            else: break # end loop if last c4 full not found
+    if len(c4) == 0: break # end loop if no full integral has been found
+    if sum(repeats) < n_samples_tot:
+        print("ERROR: some %s full samples missing: expected %d, found %d" % (index4, n_samples_tot, sum(repeats)))
         break # end loop like above
-    c2, c3, c4 = [np.array(a) for a in (c2, c3, c4)]
-    if collapse_factor > 1: c2, c3, c4 = [np.mean(a.reshape(-1, collapse_factor, *np.shape(a)[1:]), axis=1) for a in (c2, c3, c4)] # average adjacent chunks of collapse_factor samples
-    # write
-    for i in tqdm(range(n_samples_out), desc="Writing %s full samples" % index4):
-        np.savetxt(output_root_all+'c2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i), c2[i])
-        np.savetxt(output_root_all+'c3_n%d_%s_%s_%s.txt' % (n, mstr, index3, i), c3[i])
-        np.savetxt(output_root_all+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, i), c4[i])
+    c2, c3, c4, repeats = [np.array(a) for a in (c2, c3, c4, repeats)]
     # average and save
-    c2, c3, c4 = [np.mean(a, axis=0) for a in (c2, c3, c4)]
-    np.savetxt(output_root_all+'c2_n%d_%s_%s_full.txt' % (n, mstr, index2), c2)
-    np.savetxt(output_root_all+'c3_n%d_%s_%s_full.txt' % (n, mstr, index3), c3)
-    np.savetxt(output_root_all+'c4_n%d_%s_%s_full.txt' % (n, mstr, index4), c4)
+    c2f, c3f, c4f = [np.average(a, axis=0, weights=repeats) for a in (c2, c3, c4)]
+    np.savetxt(output_root_all+'c2_n%d_%s_%s_full.txt' % (n, mstr, index2), c2f)
+    np.savetxt(output_root_all+'c3_n%d_%s_%s_full.txt' % (n, mstr, index3), c3f)
+    np.savetxt(output_root_all+'c4_n%d_%s_%s_full.txt' % (n, mstr, index4), c4f)
+    if collapse_factor > 1:
+        c2, c3, c4 = [np.mean(a.reshape(n_samples_out, collapse_factor, *np.shape(a)[1:]), axis=1) for a in (c2, c3, c4)] # average adjacent chunks of collapse_factor samples; repeats must be trivial in this case
+        # write the collapsed data
+        for i in tqdm(range(n_samples_out), desc="Writing %s full samples" % index4):
+            np.savetxt(output_root_all+'c2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i), c2[i])
+            np.savetxt(output_root_all+'c3_n%d_%s_%s_%s.txt' % (n, mstr, index3, i), c3[i])
+            np.savetxt(output_root_all+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, i), c4[i])
+    else: # can copy files, which should be faster
+        c2, c3, c4 = [None] * 3 # won't be needed, so can free memory
+        for input_root_all, n_samples, sample_offset in zip(input_roots_all, ns_samples, sample_offsets):
+            for i in tqdm(range(n_samples), desc="Copying %s full samples" % index4):
+                copy2(input_root_all+'c2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i), output_root_all+'c2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i + sample_offset))
+                copy2(input_root_all+'c3_n%d_%s_%s_%s.txt' % (n, mstr, index3, i), output_root_all+'c3_n%d_%s_%s_%s.txt' % (n, mstr, index3, i + sample_offset))
+                copy2(input_root_all+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, i), output_root_all+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, i + sample_offset))
     print("Done with %s full" % index4)
 
     # jackknife integrals
     c2j, c3j, c4j = [], [], []
     EEaA1, EEaA2, RRaA1, RRaA2 = [], [], [], []
+    repeats = []
     # read
     for input_root_jack, n_samples in zip(input_roots_jack, ns_samples):
-        for i in tqdm(range(n_samples), desc="Reading %s jack samples from %s" % (index4, input_root_jack)):
+        read_all = True
+        if collapse_factor == 1 and not os.path.isfile(input_root_jack+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, n_samples)):
+            # if don't want to collapse and there are no more samples than we are using, can read averages from full file
             try:
-                c2j.append(np.loadtxt(input_root_jack+'c2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i)))
-            except (FileNotFoundError, IOError): break # end loop if c2 jack not found
-            c3j.append(np.loadtxt(input_root_jack+'c3_n%d_%s_%s_%s.txt' % (n, mstr, index3, i)))
-            c4j.append(np.loadtxt(input_root_jack+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, i)))
-            # cxj components
-            EEaA1.append(np.loadtxt(input_root_jack+'EE1_n%d_%s_%s_%s.txt' % (n, mstr, index2, i)))
-            EEaA2.append(np.loadtxt(input_root_jack+'EE2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i)))
-            RRaA1.append(np.loadtxt(input_root_jack+'RR1_n%d_%s_%s_%s.txt' % (n, mstr, index2, i)))
-            RRaA2.append(np.loadtxt(input_root_jack+'RR2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i)))
-    if len(c2j) == 0: continue # skip rest of the loop if no jack integral has been found
-    if len(c2j) < n_samples_tot:
-        print("ERROR: some %s jack samples missing: expected %d, found %d" % (index4, n_samples_tot, len(c2j)))
-        continue # skip the rest of the loop like above
-    c2j, c3j, c4j, EEaA1, EEaA2, RRaA1, RRaA2 = [np.array(a) for a in (c2j, c3j, c4j, EEaA1, EEaA2, RRaA1, RRaA2)]
-    if collapse_factor > 1: c2j, c3j, c4j, EEaA1, EEaA2, RRaA1, RRaA2 = [np.mean(a.reshape(-1, collapse_factor, *np.shape(a)[1:]), axis=1) for a in (c2j, c3j, c4j, EEaA1, EEaA2, RRaA1, RRaA2)] # average adjacent chunks of collapse_factor samples
-    # write
-    for i in tqdm(range(n_samples_out), desc="Writing %s jack samples" % index4):
-        np.savetxt(output_root_jack+'c2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i), c2j[i])
-        np.savetxt(output_root_jack+'c3_n%d_%s_%s_%s.txt' % (n, mstr, index3, i), c3j[i])
-        np.savetxt(output_root_jack+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, i), c4j[i])
-        # cxj components
-        np.savetxt(output_root_jack+'EE1_n%d_%s_%s_%s.txt' % (n, mstr, index2, i), EEaA1[i])
-        np.savetxt(output_root_jack+'EE2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i), EEaA2[i])
-        np.savetxt(output_root_jack+'RR1_n%d_%s_%s_%s.txt' % (n, mstr, index2, i), RRaA1[i])
-        np.savetxt(output_root_jack+'RR2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i), RRaA2[i])
+                c2j.append(np.loadtxt(input_root_jack+'c2_n%d_%s_%s_full.txt' % (n, mstr, index2)))
+                c3j.append(np.loadtxt(input_root_jack+'c3_n%d_%s_%s_full.txt' % (n, mstr, index3)))
+                c4j.append(np.loadtxt(input_root_jack+'c4_n%d_%s_%s_full.txt' % (n, mstr, index4)))
+                EEaA1.append(np.loadtxt(input_root_jack+'EE1_n%d_%s_%s_full.txt' % (n, mstr, index2)))
+                EEaA2.append(np.loadtxt(input_root_jack+'EE2_n%d_%s_%s_full.txt' % (n, mstr, index2)))
+                RRaA1.append(np.loadtxt(input_root_jack+'RR1_n%d_%s_%s_full.txt' % (n, mstr, index2)))
+                RRaA2.append(np.loadtxt(input_root_jack+'RR2_n%d_%s_%s_full.txt' % (n, mstr, index2)))
+                repeats.append(n_samples)
+                read_all = False
+            except (FileNotFoundError, IOError): pass
+        if read_all:
+            if os.path.isfile(input_root_jack+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, n_samples-1)):
+                for i in tqdm(range(n_samples), desc="Reading %s jack samples" % index4):
+                    c2j.append(np.loadtxt(input_root_jack+'c2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i)))
+                    c3j.append(np.loadtxt(input_root_jack+'c3_n%d_%s_%s_%s.txt' % (n, mstr, index3, i)))
+                    c4j.append(np.loadtxt(input_root_jack+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, i)))
+                    # cxj components
+                    EEaA1.append(np.loadtxt(input_root_jack+'EE1_n%d_%s_%s_%s.txt' % (n, mstr, index2, i)))
+                    EEaA2.append(np.loadtxt(input_root_jack+'EE2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i)))
+                    RRaA1.append(np.loadtxt(input_root_jack+'RR1_n%d_%s_%s_%s.txt' % (n, mstr, index2, i)))
+                    RRaA2.append(np.loadtxt(input_root_jack+'RR2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i)))
+                    repeats.append(1)
+            else: break # end loop if last c4 jack not found
+    if len(c4j) == 0: continue # skip rest of the loop if no jack integral has been found
+    if sum(repeats) < n_samples_tot:
+        print("ERROR: some %s jack samples missing: expected %d, found %d" % (index4, n_samples_tot, sum(repeats)))
+        continue # skip the rest of the loop
+    c2j, c3j, c4j, EEaA1, EEaA2, RRaA1, RRaA2, repeats = [np.array(a) for a in (c2j, c3j, c4j, EEaA1, EEaA2, RRaA1, RRaA2, repeats)]
     # average and save
-    c2j, c3j, c4j, EEaA1, EEaA2, RRaA1, RRaA2 = [np.mean(a, axis=0) for a in (c2j, c3j, c4j, EEaA1, EEaA2, RRaA1, RRaA2)]
-    np.savetxt(output_root_jack+'c2_n%d_%s_%s_full.txt' % (n, mstr, index2), c2j)
-    np.savetxt(output_root_jack+'c3_n%d_%s_%s_full.txt' % (n, mstr, index3), c3j)
-    np.savetxt(output_root_jack+'c4_n%d_%s_%s_full.txt' % (n, mstr, index4), c4j)
+    c2jf, c3jf, c4jf, EEaA1f, EEaA2f, RRaA1f, RRaA2f = [np.average(a, axis=0, weights=repeats) for a in (c2j, c3j, c4j, EEaA1, EEaA2, RRaA1, RRaA2)]
+    np.savetxt(output_root_jack+'c2_n%d_%s_%s_full.txt' % (n, mstr, index2), c2jf)
+    np.savetxt(output_root_jack+'c3_n%d_%s_%s_full.txt' % (n, mstr, index3), c3jf)
+    np.savetxt(output_root_jack+'c4_n%d_%s_%s_full.txt' % (n, mstr, index4), c4jf)
     # cxj components
-    np.savetxt(output_root_jack+'EE1_n%d_%s_%s_full.txt' % (n, mstr, index2), EEaA1)
-    np.savetxt(output_root_jack+'EE2_n%d_%s_%s_full.txt' % (n, mstr, index2), EEaA2)
-    np.savetxt(output_root_jack+'RR1_n%d_%s_%s_full.txt' % (n, mstr, index2), RRaA1)
-    np.savetxt(output_root_jack+'RR2_n%d_%s_%s_full.txt' % (n, mstr, index2), RRaA2)
+    np.savetxt(output_root_jack+'EE1_n%d_%s_%s_full.txt' % (n, mstr, index2), EEaA1f)
+    np.savetxt(output_root_jack+'EE2_n%d_%s_%s_full.txt' % (n, mstr, index2), EEaA2f)
+    np.savetxt(output_root_jack+'RR1_n%d_%s_%s_full.txt' % (n, mstr, index2), RRaA1f)
+    np.savetxt(output_root_jack+'RR2_n%d_%s_%s_full.txt' % (n, mstr, index2), RRaA2f)
+    if collapse_factor > 1:
+        c2j, c3j, c4j, EEaA1, EEaA2, RRaA1, RRaA2 = [np.mean(a.reshape(n_samples_out, collapse_factor, *np.shape(a)[1:]), axis=1) for a in (c2j, c3j, c4j, EEaA1, EEaA2, RRaA1, RRaA2)] # average adjacent chunks of collapse_factor samples
+        # write the collapsed data
+        for i in tqdm(range(n_samples_out), desc="Writing %s jack samples" % index4):
+            np.savetxt(output_root_jack+'c2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i), c2j[i])
+            np.savetxt(output_root_jack+'c3_n%d_%s_%s_%s.txt' % (n, mstr, index3, i), c3j[i])
+            np.savetxt(output_root_jack+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, i), c4j[i])
+            # cxj components
+            np.savetxt(output_root_jack+'EE1_n%d_%s_%s_%s.txt' % (n, mstr, index2, i), EEaA1[i])
+            np.savetxt(output_root_jack+'EE2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i), EEaA2[i])
+            np.savetxt(output_root_jack+'RR1_n%d_%s_%s_%s.txt' % (n, mstr, index2, i), RRaA1[i])
+            np.savetxt(output_root_jack+'RR2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i), RRaA2[i])
+    else: # can copy files, which should be faster
+        c2j, c3j, c4j, EEaA1, EEaA2, RRaA1, RRaA2 = [None] * 7 # won't be needed, so can free memory
+        for input_root_jack, n_samples, sample_offset in zip(input_roots_jack, ns_samples, sample_offsets):
+            for i in tqdm(range(n_samples), desc="Copying %s full samples" % index4):
+                copy2(input_root_jack+'c2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i), output_root_jack+'c2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i + sample_offset))
+                copy2(input_root_jack+'c3_n%d_%s_%s_%s.txt' % (n, mstr, index3, i), output_root_jack+'c3_n%d_%s_%s_%s.txt' % (n, mstr, index3, i + sample_offset))
+                copy2(input_root_jack+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, i), output_root_jack+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, i + sample_offset))
+                # cxj components
+                copy2(input_root_jack+'EE1_n%d_%s_%s_%s.txt' % (n, mstr, index2, i), output_root_jack+'EE1_n%d_%s_%s_%s.txt' % (n, mstr, index2, i + sample_offset))
+                copy2(input_root_jack+'EE2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i), output_root_jack+'EE2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i + sample_offset))
+                copy2(input_root_jack+'RR1_n%d_%s_%s_%s.txt' % (n, mstr, index2, i), output_root_jack+'RR1_n%d_%s_%s_%s.txt' % (n, mstr, index2, i + sample_offset))
+                copy2(input_root_jack+'RR2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i), output_root_jack+'RR2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i + sample_offset))
     print("Done with %s jack" % index4)

--- a/python/cat_subsets_of_integrals.py
+++ b/python/cat_subsets_of_integrals.py
@@ -56,7 +56,7 @@ for ii in range(len(I1)): # loop over all field combinations
             c4.append(np.loadtxt(input_root_all+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, i)))
     if len(c2) == 0: break # end loop if no full integral has been found
     if len(c2) < n_samples_tot:
-        print("Some %s full samples missing: expected %d, found %d" % (index4, n_samples_tot, len(c2)))
+        print("ERROR: some %s full samples missing: expected %d, found %d" % (index4, n_samples_tot, len(c2)))
         break # end loop like above
     c2, c3, c4 = [np.array(a) for a in (c2, c3, c4)]
     if collapse_factor > 1: c2, c3, c4 = [np.mean(a.reshape(-1, collapse_factor, *np.shape(a)[1:]), axis=1) for a in (c2, c3, c4)] # average adjacent chunks of collapse_factor samples
@@ -90,7 +90,7 @@ for ii in range(len(I1)): # loop over all field combinations
             RRaA2.append(np.loadtxt(input_root_jack+'RR2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i)))
     if len(c2j) == 0: continue # skip rest of the loop if no jack integral has been found
     if len(c2j) < n_samples_tot:
-        print("Some %s jack samples missing: expected %d, found %d" % (index4, n_samples_tot, len(c2j)))
+        print("ERROR: some %s jack samples missing: expected %d, found %d" % (index4, n_samples_tot, len(c2j)))
         continue # skip the rest of the loop like above
     c2j, c3j, c4j, EEaA1, EEaA2, RRaA1, RRaA2 = [np.array(a) for a in (c2j, c3j, c4j, EEaA1, EEaA2, RRaA1, RRaA2)]
     if collapse_factor > 1: c2j, c3j, c4j, EEaA1, EEaA2, RRaA1, RRaA2 = [np.mean(a.reshape(-1, collapse_factor, *np.shape(a)[1:]), axis=1) for a in (c2j, c3j, c4j, EEaA1, EEaA2, RRaA1, RRaA2)] # average adjacent chunks of collapse_factor samples

--- a/python/cat_subsets_of_integrals.py
+++ b/python/cat_subsets_of_integrals.py
@@ -5,6 +5,7 @@
 
 import numpy as np
 import sys,os
+from tqdm import tqdm
 
 # PARAMETERS
 if len(sys.argv)<6: # if too few
@@ -48,7 +49,7 @@ for ii in range(len(I1)): # loop over all field combinations
     c2, c3, c4 = [], [], []
     # read
     for input_root_all, n_samples in zip(input_roots_all, ns_samples):
-        for i in range(n_samples):
+        for i in tqdm(range(n_samples), desc="Reading %s full samples from %s" % (index4, input_root_all)):
             try:
                 c2.append(np.loadtxt(input_root_all+'c2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i)))
             except (FileNotFoundError, IOError): break # end loop if c2 full not found
@@ -61,7 +62,7 @@ for ii in range(len(I1)): # loop over all field combinations
     c2, c3, c4 = [np.array(a) for a in (c2, c3, c4)]
     if collapse_factor > 1: c2, c3, c4 = [np.mean(a.reshape(-1, collapse_factor, *np.shape(a)[1:]), axis=1) for a in (c2, c3, c4)] # average adjacent chunks of collapse_factor samples
     # write
-    for i in range(n_samples_out):
+    for i in tqdm(range(n_samples_out), desc="Writing %s full samples" % index4):
         np.savetxt(output_root_all+'c2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i), c2[i])
         np.savetxt(output_root_all+'c3_n%d_%s_%s_%s.txt' % (n, mstr, index3, i), c3[i])
         np.savetxt(output_root_all+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, i), c4[i])
@@ -77,7 +78,7 @@ for ii in range(len(I1)): # loop over all field combinations
     EEaA1, EEaA2, RRaA1, RRaA2 = [], [], [], []
     # read
     for input_root_jack, n_samples in zip(input_roots_jack, ns_samples):
-        for i in range(n_samples):
+        for i in tqdm(range(n_samples), desc="Reading %s jack samples from %s" % (index4, input_root_jack)):
             try:
                 c2j.append(np.loadtxt(input_root_jack+'c2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i)))
             except (FileNotFoundError, IOError): break # end loop if c2 jack not found
@@ -95,7 +96,7 @@ for ii in range(len(I1)): # loop over all field combinations
     c2j, c3j, c4j, EEaA1, EEaA2, RRaA1, RRaA2 = [np.array(a) for a in (c2j, c3j, c4j, EEaA1, EEaA2, RRaA1, RRaA2)]
     if collapse_factor > 1: c2j, c3j, c4j, EEaA1, EEaA2, RRaA1, RRaA2 = [np.mean(a.reshape(-1, collapse_factor, *np.shape(a)[1:]), axis=1) for a in (c2j, c3j, c4j, EEaA1, EEaA2, RRaA1, RRaA2)] # average adjacent chunks of collapse_factor samples
     # write
-    for i in range(n_samples_out):
+    for i in tqdm(range(n_samples_out), desc="Writing %s jack samples" % index4):
         np.savetxt(output_root_jack+'c2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i), c2j[i])
         np.savetxt(output_root_jack+'c3_n%d_%s_%s_%s.txt' % (n, mstr, index3, i), c3j[i])
         np.savetxt(output_root_jack+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, i), c4j[i])

--- a/python/convert_cov_legendre_multi.py
+++ b/python/convert_cov_legendre_multi.py
@@ -1,0 +1,25 @@
+"Slightly more complicated (than convert_cov.py) convenience script that reads RascalC 2-tracer Legendre mode results and saves full cov to text file, changing the indexing from [t, r, l] to [t, l, r], in addition checking eigenvalues of bias matrix"
+
+import numpy as np
+import sys
+
+## PARAMETERS
+if len(sys.argv) != 4:
+    print("Usage: python convert_cov_legendre_multi.py {RASCALC_RESULTS_FILE} {N_R_BINS} {OUTPUT_COV_FILE}.")
+    sys.exit(1)
+rascalc_results = str(sys.argv[1])
+n = int(sys.argv[2])
+output_cov_file = str(sys.argv[3])
+
+with np.load(rascalc_results) as f:
+    cov = f['full_theory_covariance']
+    print(f"Max abs eigenvalue of bias correction matrix is {np.max(np.abs(np.linalg.eigvals(f['full_theory_D_matrix']))):.2e}")
+    # if the printed value is small the cov matrix should be safe to invert as is
+
+n_bins = len(cov)
+assert n_bins % (3*n) == 0, "Number of bins mismatch"
+n_l = n_bins // (3*n)
+cov = cov.reshape(3, n, n_l, 3, n, n_l) # convert to 6D from 2D with [t, r, l] ordering for both rows and columns
+cov = cov.transpose(0, 2, 1, 3, 5, 4) # change orderng to [t, l, r] for both rows and columns
+cov = cov.reshape(n_bins, n_bins) # convert back from 6D to 2D
+np.savetxt(output_cov_file, cov)

--- a/python/convert_to_xyz.py
+++ b/python/convert_to_xyz.py
@@ -42,21 +42,7 @@ import wcdm
 
 # Load in data:
 print("Counting lines in file")
-total_lines=0
-for n, line in enumerate(open(input_file, 'r')):
-    total_lines+=1
-
-all_ra,all_dec,all_z,all_w=[np.zeros(total_lines) for _ in range(4)]
-
-print("Reading in data");
-for n, line in enumerate(open(input_file, 'r')):
-    if n%1000000==0:
-        print("Reading line %d of %d" %(n,total_lines))
-    split_line=np.array(line.strip().split(), dtype=float) 
-    all_ra[n]=split_line[0];
-    all_dec[n]=split_line[1];
-    all_z[n]=split_line[2];
-    all_w[n]=split_line[3];
+all_ra, all_dec, all_z, all_w = np.loadtxt(input_file, usecols=range(4)).T
     
 from astropy.constants import c as c_light
 import astropy.units as u

--- a/python/create_jackknives.py
+++ b/python/create_jackknives.py
@@ -3,6 +3,8 @@
 import numpy as np
 import healpy as hp
 import sys
+import time
+from tqdm import tqdm
 
 ## PARAMETERS
 if len(sys.argv)<4:
@@ -10,8 +12,8 @@ if len(sys.argv)<4:
     sys.exit(1)
 infile_name = str(sys.argv[1])
 outfile_name = str(sys.argv[2])
-NSIDE=int(sys.argv[3])
-NEST=False # Whether to use Healpix NEST or RING ordering
+NSIDE = int(sys.argv[3])
+NEST = False # Whether to use Healpix NEST or RING ordering
 
 # First count number of lines
 print('Counting number of lines')
@@ -19,19 +21,14 @@ with open(infile_name) as f:
     for i, l in enumerate(f):
         pass
 total_lines = i + 1
-print('Found %s lines in this file' %total_lines)
+print('Found %s lines in this file' % total_lines)
 
-import time
-percent_count=0
-init=time.time()
+init = time.time()
 with open(infile_name) as infile:
-    with open(outfile_name,"w") as outfile:
-        for l,line in enumerate(infile):
-            if 100*l/total_lines>=percent_count:
-                print(" %d%% done: Reading line %s of %s" %(percent_count,l,total_lines))
-                percent_count+=1
-            split_line=line.split()
-            pix=int(hp.vec2pix(NSIDE,float(split_line[0]),float(split_line[1]),float(split_line[2]),nest=NEST))
-            outfile.write(line[:-1]+" "+str(pix)+"\n")
-end=time.time()-init
-print('Task completed in %.2f seconds' %end) 
+    with open(outfile_name, "w") as outfile:
+        for l, line in tqdm(enumerate(infile), total=total_lines, desc="Reading particles"):
+            split_line = line.split()
+            pix = int(hp.vec2pix(NSIDE, float(split_line[0]), float(split_line[1]), float(split_line[2]), nest=NEST))
+            outfile.write(line[:-1] + " " + str(pix) + "\n")
+end = time.time() - init
+print('Task completed in %.2f seconds' % end) 

--- a/python/jackknife_weights.py
+++ b/python/jackknife_weights.py
@@ -20,25 +20,10 @@ outdir=str(sys.argv[7])
 
 
 ## First read in weights and positions:
-dtype = np.double 
 
-print("Counting lines in file")
-total_lines=0
-for n, line in enumerate(open(fname, 'r')):
-    total_lines+=1
-
-X,Y,Z,W,J=[np.zeros(total_lines) for _ in range(5)]
-
-print("Reading in data");
-for n, line in enumerate(open(fname, 'r')):
-    if n%1000000==0:
-        print("Reading line %d of %d" %(n,total_lines))
-    split_line=np.array(line.split(" "), dtype=float) 
-    X[n]=split_line[0];
-    Y[n]=split_line[1];
-    Z[n]=split_line[2];
-    W[n]=split_line[3];
-    J[n]=int(split_line[4]);
+print("Reading in data")
+X, Y, Z, W, J = np.loadtxt(fname, usecols=range(5)).T
+J = J.astype(int) # jackknife region is integer
 
 #J = np.array(J,dtype=int) # convert jackknives to integers
 N = len(X) # number of particles

--- a/python/jackknife_weights_cross.py
+++ b/python/jackknife_weights_cross.py
@@ -22,41 +22,14 @@ outdir=str(sys.argv[8])
 
 
 ## First read in weights and positions:
-dtype = np.double 
 
-print("Counting lines in file 1 of 2")
-total_lines=0
-for n, line in enumerate(open(fname, 'r')):
-    total_lines+=1
-print("Counting lines in file 2 of 2")
-total_lines2=0
-for n, line in enumerate(open(fname2,'r')):
-    total_lines2+=1
+print("\nReading in data from file 1:")
+X, Y, Z, W, J = np.loadtxt(fname, usecols=range(5)).T
+J = J.astype(int) # jackknife region is integer
 
-X,Y,Z,W,J=[np.zeros(total_lines) for _ in range(5)]
-X2,Y2,Z2,W2,J2=[np.zeros(total_lines2) for _ in range(5)]
-
-print("\nReading in data from file 1:");
-for n, line in enumerate(open(fname, 'r')):
-    if n%1000000==0:
-        print("Reading line %d of %d" %(n,total_lines))
-    split_line=np.array(line.split(" "), dtype=float) 
-    X[n]=split_line[0];
-    Y[n]=split_line[1];
-    Z[n]=split_line[2];
-    W[n]=split_line[3];
-    J[n]=int(split_line[4]);
-
-print("\nReading in data from file 2:");
-for n, line in enumerate(open(fname2, 'r')):
-    if n%1000000==0:
-        print("Reading line %d of %d" %(n,total_lines2))
-    split_line=np.array(line.split(" "), dtype=float) 
-    X2[n]=split_line[0];
-    Y2[n]=split_line[1];
-    Z2[n]=split_line[2];
-    W2[n]=split_line[3];
-    J2[n]=int(split_line[4]);
+print("\nReading in data from file 2:")
+X2, Y2, Z2, W2, J2 = np.loadtxt(fname2, usecols=range(5)).T
+J2 = J2.astype(int) # jackknife region is integer
 
 N = len(X) # number of particles
 N2 = len(X2)

--- a/python/post_process_3pcf.py
+++ b/python/post_process_3pcf.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 import sys,os
+from tqdm import trange
 
 # PARAMETERS
 if len(sys.argv)!=6 and len(sys.argv)!=7:
@@ -73,9 +74,8 @@ n_bins = len(c6)
 print("Computing the full precision matrix estimate:")
 # Load in partial theoretical matrices
 c3s, c4s, c5s, c6s = [], [], [], []
-for i in range(n_samples):
-    print("Loading full subsample %d of %d"%(i+1,n_samples))
-    c3t,c4t,c5t,c6t=load_matrices(i)
+for i in trange(n_samples, desc="Loading full subsamples"):
+    c3t, c4t, c5t, c6t = load_matrices(i)
     c3s.append(c3t)
     c4s.append(c4t)
     c5s.append(c5t)

--- a/python/post_process_default.py
+++ b/python/post_process_default.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 import sys,os
+from tqdm import trange
 
 # PARAMETERS
 if len(sys.argv)!=6 and len(sys.argv)!=7:
@@ -54,9 +55,8 @@ n_bins = len(c4)
 print("Computing the full precision matrix estimate:")
 # Load in partial theoretical matrices
 c2s,c3s,c4s=[],[],[]
-for i in range(n_samples):
-    print("Loading full subsample %d of %d"%(i+1,n_samples))
-    c2,c3,c4=load_matrices(i)
+for i in trange(n_samples, desc="Loading full subsamples"):
+    c2, c3, c4 = load_matrices(i)
     c2s.append(c2)
     c3s.append(c3)
     c4s.append(c4)

--- a/python/post_process_default_mocks.py
+++ b/python/post_process_default_mocks.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 import sys,os
+from tqdm import trange
 
 # PARAMETERS
 if len(sys.argv) not in (7, 8):
@@ -52,9 +53,8 @@ n_bins = len(c4f)
 
 # Load in partial theoretical matrices
 c2s, c3s, c4s = [], [], []
-for i in range(n_samples):
-    print("Loading full subsample %d of %d"%(i+1,n_samples))
-    c2,c3,c4=load_matrices(i)
+for i in trange(n_samples, desc="Loading full subsamples"):
+    c2, c3, c4 = load_matrices(i)
     c2s.append(c2)
     c3s.append(c3)
     c4s.append(c4)

--- a/python/post_process_default_mocks_multi.py
+++ b/python/post_process_default_mocks_multi.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 import sys,os
+from tqdm import trange
 
 # PARAMETERS
 if len(sys.argv) not in (7, 8):
@@ -69,8 +70,7 @@ for i, index in enumerate(indices):
 
     # Load in partial jackknife theoretical matrices
     c2s, c3s, c4s = [], [], []
-    for j in range(n_samples):
-        print("Loading field %d subsample %d of %d" % (i+1, j+1, n_samples))
+    for j in trange(n_samples, desc=f"Loading field {i+1} subsamples"):
         c2, c3, c4 = load_matrices(j, i+1)
         c2s.append(c2)
         c3s.append(c3)
@@ -221,7 +221,7 @@ n_bins = len(c_tot[0,0])
 
 # Load subsampled matrices (all submatrices combined)
 c_subsamples=[]
-for i in range(n_samples):
+for i in trange(n_samples, desc="Loading full subsamples"):
     _, tmp = matrix_readin(i)
     c_subsamples.append(tmp)
 c_subsamples = np.array(c_subsamples)

--- a/python/post_process_default_multi.py
+++ b/python/post_process_default_multi.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 import sys,os
+from tqdm import trange
 
 # PARAMETERS
 if len(sys.argv) not in (6, 8):
@@ -138,8 +139,8 @@ n_bins = len(c_tot[0,0])
 
 # Load subsampled matrices (all submatrices combined)
 c_subsamples=[]
-for i in range(n_samples):
-    _,tmp=matrix_readin(i)
+for i in trange(n_samples, desc="Loading full subsamples"):
+    _, tmp = matrix_readin(i)
     c_subsamples.append(tmp)
 c_subsamples = np.array(c_subsamples)
 

--- a/python/post_process_jackknife.py
+++ b/python/post_process_jackknife.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 import sys,os
+from tqdm import trange
 
 # PARAMETERS
 if len(sys.argv)!=7:
@@ -94,9 +95,8 @@ if min(eig_c4)<-1.*min(eig_c2):
 
 # Load in partial jackknife theoretical matrices
 c2s, c3s, c4s = [], [], []
-for i in range(n_samples):
-    print("Loading jackknife subsample %d of %d"%(i+1,n_samples))
-    c2,c3,c4=load_matrices(i)
+for i in trange(n_samples, "Loading jackknife subsamples"):
+    c2, c3, c4 = load_matrices(i)
     c2s.append(c2)
     c3s.append(c3)
     c4s.append(c4)
@@ -149,9 +149,8 @@ if min(eig_c4f)<min(eig_c2f)*-1.:
 print("Computing the full precision matrix estimate:")
 # Load in partial jackknife theoretical matrices
 c2fs, c3fs, c4fs = [], [], []
-for i in range(n_samples):
-    print("Loading full subsample %d of %d"%(i+1,n_samples))
-    c2,c3,c4=load_matrices(i,jack=False)
+for i in trange(n_samples, desc="Loading full subsamples"):
+    c2, c3, c4 = load_matrices(i, jack=False)
     c2fs.append(c2)
     c3fs.append(c3)
     c4fs.append(c4)

--- a/python/post_process_jackknife_multi.py
+++ b/python/post_process_jackknife_multi.py
@@ -4,6 +4,7 @@
 
 import numpy as np
 import sys,os
+from tqdm import tqdm
 
 # PARAMETERS
 if len(sys.argv)!=9:
@@ -149,8 +150,7 @@ for i,index in enumerate(indices):
 
     # Load in partial jackknife theoretical matrices
     c2s, c3s, c4s = [], [], []
-    for j in range(n_samples):
-        print("Loading field %d jackknife subsample %d of %d"%(i+1,j+1,n_samples))
+    for j in tqdm(range(n_samples), f"Loading field {i+1} jackknife subsamples"):
         c2,c3,c4=load_matrices(j,i+1)
         c2s.append(c2)
         c3s.append(c3)
@@ -365,8 +365,8 @@ n_bins = len(c_tot[0,0])
 
 # Load subsampled matrices
 c_subsamples,cj_subsamples=[],[]
-for i in range(n_samples):
-    _,tmp,_,tmpj=matrix_readin(i)
+for i in tqdm(range(n_samples), "Loading full and jackknife subsamples"):
+    _, tmp, _, tmpj = matrix_readin(i)
     c_subsamples.append(tmp)
     cj_subsamples.append(tmpj)
 

--- a/python/post_process_legendre.py
+++ b/python/post_process_legendre.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 import sys, os
-from tqdm import tqdm
+from tqdm import trange
 
 # PARAMETERS
 if len(sys.argv) not in (6, 7, 8, 9):
@@ -61,8 +61,8 @@ n_bins = len(c4)
 print("Computing the full precision matrix estimate:")
 # Load in partial theoretical matrices
 c2s, c3s, c4s = [], [], []
-for i in tqdm(range(n_samples), desc="Loading full subsamples"):
-    c2t,c3t,c4t=load_matrices(i)
+for i in trange(n_samples, desc="Loading full subsamples"):
+    c2t, c3t, c4t = load_matrices(i)
     c2s.append(c2t)
     c3s.append(c3t)
     c4s.append(c4t)

--- a/python/post_process_legendre.py
+++ b/python/post_process_legendre.py
@@ -2,7 +2,8 @@
 ## We output the theoretical covariance matrices, (quadratic-bias corrected) precision matrices and the effective number of samples, N_eff.
 
 import numpy as np
-import sys,os
+import sys, os
+from tqdm import tqdm
 
 # PARAMETERS
 if len(sys.argv) not in (6, 7, 8, 9):
@@ -60,8 +61,7 @@ n_bins = len(c4)
 print("Computing the full precision matrix estimate:")
 # Load in partial theoretical matrices
 c2s, c3s, c4s = [], [], []
-for i in range(n_samples):
-    print("Loading full subsample %d of %d"%(i+1,n_samples))
+for i in tqdm(range(n_samples), desc="Loading full subsamples"):
     c2t,c3t,c4t=load_matrices(i)
     c2s.append(c2t)
     c3s.append(c3t)

--- a/python/post_process_legendre_multi.py
+++ b/python/post_process_legendre_multi.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 import sys,os
+from tqdm import trange
 
 # PARAMETERS
 if len(sys.argv) not in (6, 8):
@@ -138,8 +139,8 @@ n_bins = len(c_tot[0,0])
 
 # Load subsampled matrices (all submatrices combined)
 c_subsamples=[]
-for i in range(n_samples):
-    _,tmp=matrix_readin(i)
+for i in trange(n_samples, desc="Loading full subsamples"):
+    _, tmp = matrix_readin(i)
     c_subsamples.append(tmp)
 
 # Now compute all precision matrices

--- a/python/take_subset_of_particles.py
+++ b/python/take_subset_of_particles.py
@@ -3,6 +3,7 @@
 import numpy as np
 import sys
 import time
+from tqdm import tqdm
 init_time=time.time()
 
 if len(sys.argv)<4:
@@ -10,7 +11,7 @@ if len(sys.argv)<4:
     sys.exit(1)
 infile_name = str(sys.argv[1])
 outfile_name = str(sys.argv[2])
-N=int(sys.argv[3])
+N = int(sys.argv[3])
     
 # First count number of lines
 print('Counting particles in file')
@@ -18,31 +19,23 @@ with open(infile_name) as f:
     for i, l in enumerate(f):
         pass
 total_lines = i + 1
-print('Found %s lines in this file' %total_lines)
+print('Found %s lines in this file' % total_lines)
 
 # Now create an ordered list of random particle numbers from the list of particles
-list_of_indices=np.arange(0,total_lines)
-random_indices=np.random.choice(list_of_indices,N,replace=False)
+list_of_indices = np.arange(0,total_lines)
+random_indices = np.random.choice(list_of_indices,N,replace=False)
 random_indices.sort()
 
-count=0 # number of particles chosen so far
-perc_count=0 # percentage completion counter
+count = 0 # number of particles chosen so far
 
 # Now read in correct particles and save to a file
 with open(infile_name) as infile:
-    with open(outfile_name,"w") as outfile:
-        for l,line in enumerate(infile):
-            if l==random_indices[count]:
-                count +=1
-                perc=float(count)/float(N)*100.
-                if perc>=perc_count:
-                    print("Read in particle %d of %d: %d%% Complete" %(count,N,perc_count))
-                    perc_count+=5
+    with open(outfile_name, "w") as outfile:
+        for l, line in tqdm(enumerate(infile), total=total_lines, desc="Reading particles"):
+            if l == random_indices[count]:
+                count += 1
                 outfile.write(line)
-            if count>=N:
-                break
-            else:
-                pass
+            if count >= N: break # have chosen the required number of particles, can skip the rest of the loop
             
-end=time.time()-init_time
-print('Task took %d seconds in total and uses %.2f%% of the available particles' %(end,float(N)/float(total_lines)*100.)) 
+end = time.time() - init_time
+print('Task took %d seconds in total and uses %.2f%% of the available particles' % (end, float(N)/float(total_lines)*100.)) 

--- a/python/xi_estimator_aperiodic.py
+++ b/python/xi_estimator_aperiodic.py
@@ -57,18 +57,7 @@ def reader(filename,only_length=False):
     if only_length:
         return total_lines
 
-    X,Y,Z,W=[np.zeros(total_lines) for _ in range(4)]
-
-    for n, line in enumerate(open(filename, 'r')):
-        if n%1000000==0:
-            print("Reading line %d of %d from file %s" %(n,total_lines,filename))
-        split_line=np.array(line.split(), dtype=float)
-        X[n]=split_line[0];
-        Y[n]=split_line[1];
-        Z[n]=split_line[2];
-        W[n]=split_line[3];
-
-    return X,Y,Z,W
+    return np.loadtxt(filename, usecols=range(4)).T
 
 ## Read galaxy files
 data1 = reader(Dname1)

--- a/python/xi_estimator_jack.py
+++ b/python/xi_estimator_jack.py
@@ -28,49 +28,21 @@ else:
     RRname=""
 
 ## First read in weights and positions:
-dtype = np.double 
-
 # Read first set of randoms
-print("Counting lines in DR random file")
-total_lines=0
-for n, line in enumerate(open(RnameDR, 'r')):
-    total_lines+=1
 
-rX_DR,rY_DR,rZ_DR,rW_DR,rJ_DR=[np.zeros(total_lines) for _ in range(5)]
-
-print("Reading in DR random data");
-for n, line in enumerate(open(RnameDR, 'r')):
-    if n%1000000==0:
-        print("Reading line %d of %d" %(n,total_lines))
-    split_line=np.array(line.split(" "), dtype=float) 
-    rX_DR[n]=split_line[0];
-    rY_DR[n]=split_line[1];
-    rZ_DR[n]=split_line[2];
-    rW_DR[n]=split_line[3];
-    rJ_DR[n]=split_line[4];
+print("Reading in DR random data")
+rX_DR, rY_DR, rZ_DR, rW_DR, rJ_DR = np.loadtxt(RnameDR, usecols=range(5)).T
+rJ_DR = rJ_DR.astype(int) # jackknife region is integer
 
 N_randDR = len(rX_DR) # number of particles
 
 if len(RRname)==0:
     if RnameRR!=RnameDR:
         # only read in RR file if distinct from DR and needed by the code:
-        print("Counting lines in RR random file")
-        total_lines=0
-        for n, line in enumerate(open(RnameRR, 'r')):
-            total_lines+=1
 
-        rX_RR,rY_RR,rZ_RR,rW_RR,rJ_RR=[np.zeros(total_lines) for _ in range(5)]
-
-        print("Reading in RR random data");
-        for n, line in enumerate(open(RnameRR, 'r')):
-            if n%1000000==0:
-                print("Reading line %d of %d" %(n,total_lines))
-            split_line=np.array(line.split(" "), dtype=float) 
-            rX_RR[n]=split_line[0];
-            rY_RR[n]=split_line[1];
-            rZ_RR[n]=split_line[2];
-            rW_RR[n]=split_line[3];
-            rJ_RR[n]=split_line[4];
+        print("Reading in RR random data")
+        rX_RR, rY_RR, rZ_RR, rW_RR, rJ_RR = np.loadtxt(RnameRR, usecols=range(5)).T
+        rJ_RR = rJ_RR.astype(int) # jackknife region is integer
             
         N_randRR = len(rX_RR) # number of particles
     else:
@@ -89,23 +61,9 @@ else:
     for n, line in enumerate(open(RnameRR, 'r')):
         N_randRR+=1
 
-print("Counting lines in galaxy file")
-total_lines=0
-for n, line in enumerate(open(Dname, 'r')):
-    total_lines+=1
-
-dX,dY,dZ,dW,dJ=[np.zeros(total_lines) for _ in range(5)]
-
-print("Reading in galaxy data");
-for n, line in enumerate(open(Dname, 'r')):
-    if n%1000000==0:
-        print("Reading line %d of %d" %(n,total_lines))
-    split_line=np.array(line.split(" "), dtype=float) 
-    dX[n]=split_line[0];
-    dY[n]=split_line[1];
-    dZ[n]=split_line[2];
-    dW[n]=split_line[3];
-    dJ[n]=int(split_line[4]);
+print("Reading in galaxy data")
+dX, dY, dZ, dW, dJ = np.loadtxt(Dname, usecols=range(5)).T
+dJ = dJ.astype(int) # jackknife region is integer
 
 N_gal = len(dX) # number of particles
 

--- a/python/xi_estimator_jack_cross.py
+++ b/python/xi_estimator_jack_cross.py
@@ -47,18 +47,9 @@ def reader(filename,only_length=False):
     if only_length:
         return total_lines
     
-    X,Y,Z,W,J=[np.zeros(total_lines) for _ in range(5)]
-    
-    for n, line in enumerate(open(filename, 'r')):
-        if n%1000000==0:
-            print("Reading line %d of %d from file %s" %(n,total_lines,filename))
-        split_line=np.array(line.split(" "), dtype=float) 
-        X[n]=split_line[0];
-        Y[n]=split_line[1];
-        Z[n]=split_line[2];
-        W[n]=split_line[3];
-        J[n]=int(split_line[4]);
-    return X,Y,Z,W,J
+    X, Y, Z, W, J = np.loadtxt(filename, usecols=range(5)).T
+    J = J.astype(int) # jackknife region is integer
+    return X, Y, Z, W, J
 
 ## Read galaxy files
 data1 = reader(Dname1)

--- a/python/xi_estimator_periodic.py
+++ b/python/xi_estimator_periodic.py
@@ -33,20 +33,10 @@ total_lines=0
 for n, line in enumerate(open(Dname, 'r')):
     total_lines+=1
 
-dX,dY,dZ,dW=[np.zeros(total_lines) for _ in range(4)]
-
 print("Reading in galaxy data");
-for n, line in enumerate(open(Dname, 'r')):
-    if n%1000000==0:
-        print("Reading line %d of %d" %(n,total_lines))
-    split_line=np.array(line.split(), dtype=float)
-    dX[n]=split_line[0];
-    dY[n]=split_line[1];
-    dZ[n]=split_line[2];
-    if len(split_line)>3:
-        dW[n]=split_line[3];
-    else:
-        dW[n]=1.
+tmp = np.loadtxt(Dname, usecols=range(4)).T
+dX, dY, dZ = tmp[:3]
+dW = tmp[3] if len(tmp) >= 4 else np.ones_like(dX)
 
 N_gal = len(dX) # number of particles
 
@@ -63,22 +53,10 @@ assert(np.abs(zrange-boxsize)/boxsize<0.001),'Data is not periodic! Z-range is %
 
 if multifield:
 
-    print("Counting lines in galaxy file 2")
-    total_lines2=0
-    for n, line in enumerate(open(Dname2,'r')):
-        total_lines2+=1
-
-    dX2,dY2,dZ2,dW2=[np.zeros(total_lines2) for _ in range(4)]
-
     print("Reading in galaxy data for galaxy 2");
-    for n, line in enumerate(open(Dname2, 'r')):
-        if n%1000000==0:
-            print("Reading line %d of %d" %(n,total_lines2))
-        split_line=np.array(line.split(), dtype=float)
-        dX2[n]=split_line[0];
-        dY2[n]=split_line[1];
-        dZ2[n]=split_line[2];
-        dW2[n]=split_line[3];
+    tmp = np.loadtxt(Dname, usecols=range(4)).T
+    dX2, dY2, dZ2 = tmp[:3]
+    dW2 = tmp[3] if len(tmp) >= 4 else np.ones_like(dX2)
 
     N_gal2 = len(dX2) # number of particles
     print("Number of galaxy particles in second set: %.1e"%N_gal2)


### PR DESCRIPTION
C++ code:
* Option for grouping a number of loops into one output subsample. Too many subsamples make post-processing long with almost no advantage, while more loops can help to achieve better load balancing between threads.
* "Shooting" procedure for `nside` (sampling grid size), reducing the need to find its right value by manual trial and error.
* Deleted early exit logic by Frobenius percent difference criterion, because it could be unpredictable, especially in multi-tracer mode where different integrals may end after a different number of subsamples.
* Loop timing diagnostic.
* Modified thread seed calculation.
* Added a Makefile switch to suppress each thread percent progress messages, because it can be a lot of output. On the other hand, with 1 loop per thread, no such output might leave one uncertain about how the code is running and thus not removed completely.
* Optimized bin lookup for 2PCF rescaling (the same binary search algorithm as introduced for main integrals computations earlier).

Python utilities:
* Conversion script for multi-tracer Legendre covariance, transposing it from internal (tracer, radial bin, multipole) ordering to (tracer, multipole, radial bin) used e.g. in DESI.
* Fixes, optimizations, and clarified messages in subsample catenation script.
* `tqdm` instead of several different ways to report progress.
* Removed manual text file loading when `np.loadtxt` is easy to use.