### PR TITLE
Survey correction usage fix

### DIFF
--- a/docs/usage/geometry-correction.rst
+++ b/docs/usage/geometry-correction.rst
@@ -55,11 +55,11 @@ Usage
 
 For a single field analysis::
 
-    python python/compute_correction_function.py {GALAXY_FILE} {BIN_FILE} {OUTPUT_DIR} {PERIODIC} [{RR_COUNTS}]
+    python python/compute_correction_function.py {RANDOM_PARTICLE_FILE} {BIN_FILE} {OUTPUT_DIR} {PERIODIC} [{RR_COUNTS}]
 
 For an analysis using two distinct fields::
 
-    python python/compute_correction_function_multi.py {GALAXY_FILE} {GALAXY_FILE_2} {BIN_FILE} {OUTPUT_DIR} {PERIODIC} [{RR_COUNTS_11} {RR_COUNTS_12} {RR_COUNTS_22}]
+    python python/compute_correction_function_multi.py {RANDOM_PARTICLE_FILE_1} {RANDOM_PARTICLE_FILE_2} {BIN_FILE} {OUTPUT_DIR} {PERIODIC} [{RR_COUNTS_11} {RR_COUNTS_12} {RR_COUNTS_22}]
 
 **Input Parameters**:
 
@@ -108,7 +108,7 @@ Usage
 ~~~~~~
  ::
 
-    python python/compute_3pcf_correction_function.py {GALAXY_FILE} {BIN_FILE} {OUTPUT_DIR} {PERIODIC} [{RRR_COUNTS}]
+    python python/compute_3pcf_correction_function.py {RANDOM_PARTICLE_FILE} {BIN_FILE} {OUTPUT_DIR} {PERIODIC} [{RRR_COUNTS}]
 
 **Input Parameters**:
 

--- a/docs/usage/tutorial_periodic.rst
+++ b/docs/usage/tutorial_periodic.rst
@@ -68,7 +68,7 @@ This uses Corrfunc to perform pair counting and computes :math:`\xi_a` for each 
 
 The main C++ code requires an input *survey correction function* to account for non-trivial survey geometries. For a periodic box, the correction function :math:`\Phi(r_a,\mu)` is constant, but the normalization carries important information including the survey volume and number density. This is simply computed via::
 
-    python python/compute_correction_function.py nbody_simulation.txt radial_binning_cov.csv ./ 1
+    python python/compute_correction_function.py nbody_randoms_10x.txt radial_binning_cov.csv ./ 1
 
 (See :ref:`survey_correction_2PCF`)
 

--- a/python/cat_subsets_of_integrals.py
+++ b/python/cat_subsets_of_integrals.py
@@ -160,7 +160,7 @@ for ii in range(len(I1)): # loop over all field combinations
     else: # can copy files, which should be faster
         c2j, c3j, c4j, EEaA1, EEaA2, RRaA1, RRaA2 = [None] * 7 # won't be needed, so can free memory
         for input_root_jack, n_samples, sample_offset in zip(input_roots_jack, ns_samples, sample_offsets):
-            for i in trange(n_samples, desc="Copying %s full samples" % index4):
+            for i in trange(n_samples, desc="Copying %s jack samples" % index4):
                 copy2(input_root_jack+'c2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i), output_root_jack+'c2_n%d_%s_%s_%s.txt' % (n, mstr, index2, i + sample_offset))
                 copy2(input_root_jack+'c3_n%d_%s_%s_%s.txt' % (n, mstr, index3, i), output_root_jack+'c3_n%d_%s_%s_%s.txt' % (n, mstr, index3, i + sample_offset))
                 copy2(input_root_jack+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, i), output_root_jack+'c4_n%d_%s_%s_%s.txt' % (n, mstr, index4, i + sample_offset))

--- a/python/compute_correction_function.py
+++ b/python/compute_correction_function.py
@@ -11,7 +11,7 @@ from scipy.optimize import curve_fit
 
 # PARAMETERS
 if (len(sys.argv)!=5) and (len(sys.argv)!=6):
-    print("Usage: python compute_correction_function.py {GALAXY_FILE} {BIN_FILE} {OUTPUT_DIR} {PERIODIC} [{RR_COUNTS}] ")
+    print("Usage: python compute_correction_function.py {RANDOM_PARTICLE_FILE} {BIN_FILE} {OUTPUT_DIR} {PERIODIC} [{RR_COUNTS}] ")
     sys.exit(1)
 gal_file = str(sys.argv[1])
 binfile = str(sys.argv[2])

--- a/python/compute_correction_function_multi.py
+++ b/python/compute_correction_function_multi.py
@@ -11,7 +11,7 @@ from scipy.optimize import curve_fit
 
 # PARAMETERS
 if len(sys.argv)!=6 and len(sys.argv)!=9:
-    print("Usage: python compute_correction_function_multi.py {GALAXY_FILE} {GALAXY_FILE_2} {BIN_FILE} {OUTPUT_DIR} {PERIODIC} [{RR_COUNTS_11} {RR_COUNTS_12} {RR_COUNTS_22}]")
+    print("Usage: python compute_correction_function_multi.py {RANDOM_PARTICLE_FILE_1} {RANDOM_PARTICLE_FILE_2} {BIN_FILE} {OUTPUT_DIR} {PERIODIC} [{RR_COUNTS_11} {RR_COUNTS_12} {RR_COUNTS_22}]")
     sys.exit(1)
 gal_file = str(sys.argv[1])
 gal_file2 = str(sys.argv[2])

--- a/python/convert_to_xyz.py
+++ b/python/convert_to_xyz.py
@@ -41,7 +41,7 @@ sys.path.insert(0, str(dirname)+'/wcdm/')
 import wcdm
 
 # Load in data:
-print("Counting lines in file")
+print("Reading in data")
 all_ra, all_dec, all_z, all_w = np.loadtxt(input_file, usecols=range(4)).T
     
 from astropy.constants import c as c_light

--- a/python/post_process_jackknife.py
+++ b/python/post_process_jackknife.py
@@ -95,7 +95,7 @@ if min(eig_c4)<-1.*min(eig_c2):
 
 # Load in partial jackknife theoretical matrices
 c2s, c3s, c4s = [], [], []
-for i in trange(n_samples, "Loading jackknife subsamples"):
+for i in trange(n_samples, desc="Loading jackknife subsamples"):
     c2, c3, c4 = load_matrices(i)
     c2s.append(c2)
     c3s.append(c3)


### PR DESCRIPTION
Major correction: survey correction function script usage.
It should read the randoms file and not galaxies because the correction function is rescaled from randoms to data in the
code.
Also, much more randoms than data could lead to an error in the scripts (too small correction function values) in aperiodic case.

Also a few minor fixes for `tqdm` progress bars from #10.